### PR TITLE
remove 'v' from version

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,6 +15,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions


### PR DESCRIPTION
Prefix v in list-all misleads during installation, as a result empty script installed

Current version list:

```bash
v0.1.0  v0.1.2  v0.2.0  v0.3.0  v0.4.1  v0.4.3  v0.6.0  
v0.1.1  v0.1.3  v0.2.1  v0.4.0  v0.4.2  v0.5.0  v0.7.0  
```

after fix

```bash
0.1.0  0.1.2  0.2.0  0.3.0  0.4.1  0.4.3  0.6.0  
0.1.1  0.1.3  0.2.1  0.4.0  0.4.2  0.5.0  0.7.0  
```